### PR TITLE
유저 검색보다 보유캐릭터 검색이 더 빨리되는 현상 수정

### DIFF
--- a/LOARANG-MVVM/LOARANG-MVVM/Scenes/UserInfoView/CharactersView/CharactersViewController.swift
+++ b/LOARANG-MVVM/LOARANG-MVVM/Scenes/UserInfoView/CharactersView/CharactersViewController.swift
@@ -29,6 +29,7 @@ final class CharactersViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        viewModel.viewDidLoad()
         bindView()
     }
     
@@ -56,14 +57,19 @@ final class CharactersViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        viewModel.sections
-            .bind(onNext: { [weak self] in
-                if $0.isEmpty {
-                    self?.charactersView.activityIndicator.startAnimating()
-                } else {
-                    self?.charactersView.activityIndicator.stopAnimating()
-                }
-            }).disposed(by: disposeBag)
+        viewModel.startedLoading
+            .withUnretained(self)
+            .bind { owner, _ in
+                owner.charactersView.activityIndicator.startAnimating()
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.finishedLoading
+            .withUnretained(self)
+            .bind { owner, _ in
+                owner.charactersView.activityIndicator.stopAnimating()
+            }
+            .disposed(by: disposeBag)
     }
 }
 


### PR DESCRIPTION
수정 이유: 유저 검색인 크롤링, 보유캐릭터 검색은 api로 구성되어있는 상황에서 뷰가 나타나면 api 검색이 더 먼저 실행돼 검색되지 않은 캐릭터 검색시 '검색된 캐릭터가 없습니다'가 아니라 '보유 캐릭터가 없습니다' 라는 얼럿 노출됨
-> 보유 캐릭터를 굳이 검색할 때 할 필요가 없으며(유저가 안 볼 수도 있음 + api 사용 횟수 차감됨) 검색된 캐릭터가 없다는 얼럿 표시 위해 수정 